### PR TITLE
レイアウト・バグ修正

### DIFF
--- a/app/javascript/stylesheets/_global.scss
+++ b/app/javascript/stylesheets/_global.scss
@@ -18,6 +18,10 @@ body {
 
   a {
     color: black;
+    text-decoration: none;
+  }
+  a:hover {
+    opacity: 0.7;
   }
 
   // ページネーション自体のデザイン

--- a/app/javascript/stylesheets/components/_calendar.scss
+++ b/app/javascript/stylesheets/components/_calendar.scss
@@ -2,10 +2,22 @@
   width: 100%;
 }
 
-.calendar-heading a{
-  color: black;
-  text-decoration: none;
+.simple-calendar {
+
+  .calendar-heading a{
+    color: black;
+    text-decoration: none;
+  }
+
+  .table {
+    th {
+      color: #fff;
+    }
+  }
+
+
 }
+
 
 .calendar-heading a:hover{
   text-decoration: underline;

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -8,7 +8,7 @@
       <div class="search_form ms-4">
         <%= form_with url: search_path, local: true, method: :get do |f| %>
           <%= f.text_field :q, class: "form-control d-inline-block", type: "search", placeholder: "検索", aria_label: "検索" %>
-          <button class="btn btn-outline-success" type="submit">
+          <button class="btn" type="submit">
             <i class="fa-solid fa-magnifying-glass"></i>
           </button>
         <% end %>

--- a/app/views/public/end_users/show.html.erb
+++ b/app/views/public/end_users/show.html.erb
@@ -13,16 +13,16 @@
     </div>
     
     <ul class="nav nav-tabs justify-content-center col-sm-8">
-      <li class="nav-item col-sm-8 col-sm-auto">
+      <li class="nav-item col col-sm-auto">
         <a class="nav-link active" data-bs-toggle="tab" href="#fitness">Fitness</a>
       </li>
-      <li class="nav-item col-sm-8 col-sm-auto">
+      <li class="nav-item col col-sm-auto">
         <a class="nav-link" data-bs-toggle="tab" href="#meal">Meal</a>
       </li>
-      <li class="nav-item col-sm-8 col-sm-auto">
+      <li class="nav-item col col-sm-auto">
         <a class="nav-link" data-bs-toggle="tab" href="#blog">Blog</a>
       </li>
-      <li class="nav-item col-sm-8 col-sm-auto">
+      <li class="nav-item col col-sm-auto">
         <a class="nav-link" data-bs-toggle="tab" href="#liked">Liked Posts</a>
       </li>
     </ul>

--- a/app/views/public/end_users/show.html.erb
+++ b/app/views/public/end_users/show.html.erb
@@ -11,17 +11,18 @@
         </div>
       </div>
     </div>
-    <ul class="nav nav-tabs col-sm-8 justify-content-center">
-      <li class="nav-item">
-        <a class="nav-link active" data-bs-toggle="tab" href="#fitness">Post Fitness</a>
+    
+    <ul class="nav nav-tabs justify-content-center col-sm-8">
+      <li class="nav-item col-sm-8 col-sm-auto">
+        <a class="nav-link active" data-bs-toggle="tab" href="#fitness">Fitness</a>
       </li>
-      <li class="nav-item">
-        <a class="nav-link" data-bs-toggle="tab" href="#meal">Post Meal</a>
+      <li class="nav-item col-sm-8 col-sm-auto">
+        <a class="nav-link" data-bs-toggle="tab" href="#meal">Meal</a>
       </li>
-      <li class="nav-item">
-        <a class="nav-link" data-bs-toggle="tab" href="#blog">Post Blog</a>
+      <li class="nav-item col-sm-8 col-sm-auto">
+        <a class="nav-link" data-bs-toggle="tab" href="#blog">Blog</a>
       </li>
-      <li class="nav-item">
+      <li class="nav-item col-sm-8 col-sm-auto">
         <a class="nav-link" data-bs-toggle="tab" href="#liked">Liked Posts</a>
       </li>
     </ul>
@@ -30,14 +31,14 @@
       <div class="user-page__posts tab-pane fade show active mx-auto col-sm-8" id="fitness">
         <h2>Post Fitness</h2>
         <% if @post_workouts.count > 0 %>
-          <p>総投稿数: <%= @post_workouts.count %></p>
+          <p class="text-center pt-4">総投稿数: <%= @post_workouts.count %></p>
         <% end %> 
         <div class="post_workout d-flex justify-content-center mt-2 pb-4">
           <% if @post_workouts.exists? %>
             <%= render "public/post_workouts/index", post_workouts: @post_workouts  %>
           <% else %>
             <div class="user-page__empty-posts">
-              <p class="text-center">投稿はありません</p>
+              <p class="text-center pt-4">投稿はありません</p>
               <%= image_tag 'undraw_Post_re_mtr4.png', class: 'yet-image rounded-3 img-fluid' %>
             </div>
           <% end %> 
@@ -46,14 +47,14 @@
       <div class="tab-pane fade mx-auto col-sm-8" id="meal">
         <h2>Post Meal</h2>
         <% if @post_meals.count > 0 %>
-        <p>総投稿数: <%= @post_meals.count %></p>
+          <p class="text-center pt-4">総投稿数: <%= @post_meals.count %></p>
         <% end %> 
         <div class="posts__meal d-flex justify-content-center mt-2 mb-4">
           <% if @post_meals.exists? %>
             <%= render "public/post_meals/index", post_meals: @post_meals %>
           <% else %>
             <div class="user-page__empty-posts">
-              <p class="text-center">投稿はありません</p>
+              <p class="text-center pt-4">投稿はありません</p>
               <%= image_tag 'undraw_Post_re_mtr4.png', class: 'yet-image rounded-3 img-fluid' %>
             </div>
           <% end %> 
@@ -62,14 +63,14 @@
       <div class="tab-pane fade mx-auto col-sm-8" id="blog">
         <h2>Post Blog</h2>
         <% if @post_blogs.count > 0 %>
-          <p>総投稿数: <%= @post_meals.count %></p>
+          <p class="text-center pt-4">総投稿数: <%= @post_meals.count %></p>
         <% end %> 
         <div class="posts__blog d-flex justify-content-center mt-2 mb-4">
           <% if @post_blogs.exists? %>
             <%= render "public/post_blogs/index", post_blogs: @post_blogs  %>
           <% else %>
             <div class="user-page__empty-posts">
-              <p class="text-center">投稿はありません</p>
+              <p class="text-center pt-4">投稿はありません</p>
               <%= image_tag 'undraw_Post_re_mtr4.png', class: 'yet-image rounded-3 img-fluid' %>
             </div>
           <% end %>
@@ -79,12 +80,12 @@
         <h2 class="text-center">Liked Posts</h2>
           <div class="liked_posts  justify-content-center mt-2 mb-4">
             <% if @liked_post_workouts.present? %>
-              <div><p class="badge bg-primary">Fitness</p><%= render "public/post_workouts/index", post_workouts: @liked_post_workouts %></div>
-              <div><p class="badge bg-success">Meal<%= render "public/post_meals/index", post_meals: @liked_post_meals %></div>
-              <div><p class="badge bg-warning">Blog<%= render "public/post_blogs/index", post_blogs: @liked_post_blogs %></div>
+              <div><p class="badge bg-primary ms-4">Fitness</p><%= render "public/post_workouts/index", post_workouts: @liked_post_workouts %></div>
+              <div><p class="badge bg-success ms-4">Meal<%= render "public/post_meals/index", post_meals: @liked_post_meals %></div>
+              <div><p class="badge bg-warning ms-4">Blog<%= render "public/post_blogs/index", post_blogs: @liked_post_blogs %></div>
             <% else %>
               <div class="user-page__empty-posts mx-auto">
-                <p class="text-center">いいねした投稿はありません</p>
+                <p class="text-center pt-4">いいねした投稿はありません</p>
                 <%= image_tag 'undraw_Post_re_mtr4.png', class: 'yet-image rounded-3 img-fluid mx-auto' %>
               </div>
             <% end %>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -4,7 +4,6 @@
       <%= image_tag 'logo5.png', class: 'logo-image' %>
     </div>
     <div class="top__details col-sm-5 text-center p-4">
-      <h2>フィットネスを愛する全ての人へ</h2>
       <h4>フィットネス・食事・体重記録＆共有サービス</h4>
       <div class="top__actions d-flex justify-content-center mt-4">
         <% if current_end_user %>
@@ -18,17 +17,8 @@
     </div>
   </div>
 
-  <div class="top__introduction d-flex align-items-center justify-content-center text-center p-4">
-    <h4>OWN ONEは、<br>
-    日々のフィットネスや食事を記録したり、<br>
-    他のユーザーの投稿を見たり共有することで、<br>
-    モチベーションの維持に繋げ<br>
-    毎日のフィットネスをさらに楽しくするサービスです
-    </h4>
-  </div>
-
   <div class="top__content mt-4">
-    <h1 class="text-center fw-bold">How to Use</h1>
+    <h1 class="text-center fw-bold pt-4">How to Use</h1>
     <div class="top__description row d-flex align-items-center text-center mb-4">
       <div class="col-sm-5"><%= image_tag 'undraw_Personal_trainer_re_cnua.png', class: 'top-image img-fluid' %></div>
       <div class="col-sm-5"><h4>1. まずはユーザー登録<br>
@@ -47,8 +37,9 @@
     </div>
     <div class="top__description row d-flex align-items-center text-center mb-4">
       <div class="col-sm-5"><h4>4. コミュニケーションをとろう<br>
-      他のユーザーの投稿にいいねや<br>
-      コメントをしたり、日々のフィットネスにアイディアを取り入れましょう！</h4></div>
+      他ユーザーの投稿にアクションをつけたり、<br>
+      日々のフィットネスにアイディアを<br>
+      取り入れましょう！</h4></div>
       <div class="col-sm-5"><%= image_tag 'undraw_Social_life_re_x7t5.png', class: 'top-image img-fluid' %></div>
     </div>
     <div class="d-flex mt-4 mb-4 justify-content-center">

--- a/app/views/public/notifications/_followed_me.html.erb
+++ b/app/views/public/notifications/_followed_me.html.erb
@@ -1,12 +1,7 @@
 <%= link_to transition_path(notification) do %>
   <div>
-    <% if notification.subject.follower.guest_user? %>
-      <%= image_tag notification.subject.end_user.get_profile_image(30, 30), class: "rounded-circle" %>
-      ゲストユーザー
-    <% else %>
-      <%= image_tag notification.subject.end_user.get_profile_image(30, 30), class: "rounded-circle" %>
+      <%= image_tag notification.subject.follower.get_profile_image(30, 30), class: "rounded-circle" %>
       <%= link_to notification.subject.follower.user_name, end_user_path(notification.subject.follower) %>
-    <% end %>
     があなたをフォローしました
     <%= " (#{time_ago_in_words(notification.created_at)}前)" %>
   </div>

--- a/app/views/public/weights/_form.html.erb
+++ b/app/views/public/weights/_form.html.erb
@@ -7,7 +7,7 @@
       <%= f.number_field  :value, class: 'form-control', step: '0.1', min: '0' %>
     </div>
     <div class="weight__submit text-center">
-      <%= f.submit @weight.new_record? ? '新規作成' : '更新', class: "btn mt-4 mb-4" %>
+      <%= f.submit @weight.new_record? ? '新規作成' : '更新', class: "btn btn-success mt-4 mb-4" %>
     </div>
   </div>
 <% end %>

--- a/app/views/public/weights/index.html.erb
+++ b/app/views/public/weights/index.html.erb
@@ -13,7 +13,7 @@
   <div class="col-sm-8 w-100">
     <%= form_with url: weights_path, method: :get, class: 'd-flex gap-2' do |form| %>
       <p><%= form.date_field :month, value: params[:month] || Date.today.strftime('%Y-%m'), type: 'month', class: 'form-control' %></p>
-      <p><%= form.submit 'Select Month', class: 'btn' %></p>
+      <p><%= form.submit 'Select Month', class: 'btn btn-success' %></p>
     <% end %>
 
     <!-- チャートを表示 -->


### PR DESCRIPTION
## レイアウト・バグ修正

- TOPページの紹介文削除
- 体重投稿ボタンのフォントカラー変更
- ゲストユーザーがフォローした時のエラー修正
- マイページのタブ部分をレスポンシブ対応に修正
- カレンダーの見出しのフォントカラー変更
- ボディ部分のリンク全てにhoverで、マウスオーバー時半透明になるよう修正
